### PR TITLE
fix(contracts): force unwrap optional references in borrow functions

### DIFF
--- a/contracts/Flobot.cdc
+++ b/contracts/Flobot.cdc
@@ -560,7 +560,7 @@ contract Flobot: NonFungibleToken{
 		access(all)
 		fun borrowFlobot(id: UInt64): &Flobot.NFT?{ 
 			if self.ownedNFTs[id] != nil {
-				let ref = (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)
+				let ref = (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)!
 				let flobotNFT = ref as! &Flobot.NFT
 				return flobotNFT
 			} else {

--- a/contracts/Flovatar.cdc
+++ b/contracts/Flovatar.cdc
@@ -819,8 +819,8 @@ contract Flovatar: NonFungibleToken{
 		access(all)
 		fun borrowFlovatar(id: UInt64): &Flovatar.NFT?{ 
 			if self.ownedNFTs[id] != nil {
-				let ref = (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)
-				let flovatarNFT = ref as! &Flovatar.NFT?
+				let ref = (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)!
+				let flovatarNFT = ref as! &Flovatar.NFT
 				return flovatarNFT
 			} else {
 				return nil

--- a/contracts/FlovatarComponent.cdc
+++ b/contracts/FlovatarComponent.cdc
@@ -343,8 +343,8 @@ contract FlovatarComponent: NonFungibleToken{
 		access(all)
 		fun borrowComponent(id: UInt64): &FlovatarComponent.NFT?{ 
 			if self.ownedNFTs[id] != nil {
-				let ref = (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)
-				let componentNFT = ref as! &FlovatarComponent.NFT?
+				let ref = (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)!
+				let componentNFT = ref as! &FlovatarComponent.NFT
 				return componentNFT
 			} else {
 				return nil

--- a/contracts/FlovatarDustCollectible.cdc
+++ b/contracts/FlovatarDustCollectible.cdc
@@ -627,7 +627,7 @@ contract FlovatarDustCollectible: NonFungibleToken{
 		access(all)
 		fun borrowDustCollectible(id: UInt64): &FlovatarDustCollectible.NFT?{ 
 			if self.ownedNFTs[id] != nil {
-				let ref = (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)
+				let ref = (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)!
 				let collectibleNFT = ref as! &FlovatarDustCollectible.NFT
 				return collectibleNFT
 			} else {

--- a/contracts/FlovatarDustCollectibleAccessory.cdc
+++ b/contracts/FlovatarDustCollectibleAccessory.cdc
@@ -350,7 +350,7 @@ contract FlovatarDustCollectibleAccessory: NonFungibleToken{
 		access(all)
 		fun borrowCollectibleAccessory(id: UInt64): &FlovatarDustCollectibleAccessory.NFT?{ 
 			if self.ownedNFTs[id] != nil {
-				let ref = (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)
+				let ref = (&self.ownedNFTs[id] as &{NonFungibleToken.NFT}?)!
 				let collectibleNFT = ref as! &FlovatarDustCollectibleAccessory.NFT
 				return collectibleNFT
 			} else {


### PR DESCRIPTION
to ensure non-nil values are returned

This change improves the safety and clarity of the borrow functions by ensuring that the references to owned NFTs are not nil before proceeding with the cast, preventing potential runtime errors.